### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.2](https://github.com/loonghao/rez-lsp-server/compare/v0.1.1...v0.1.2) - 2025-06-27
+
+### Fixed
+
+- resolve release-plz multiple triggers and VSCode extension publishing issues
+- unify server binary naming across all platforms
+
+### Other
+
+- *(deps)* update dependency vite to v7
+
 ## [0.1.1](https://github.com/loonghao/rez-lsp-server/compare/v0.1.0...v0.1.1) - 2025-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rez-lsp-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-lsp-server"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "A Language Server Protocol implementation for Rez package manager with intelligent code completion, validation, and navigation"


### PR DESCRIPTION



## 🤖 New release

* `rez-lsp-server`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/loonghao/rez-lsp-server/compare/v0.1.1...v0.1.2) - 2025-06-27

### Fixed

- resolve release-plz multiple triggers and VSCode extension publishing issues
- unify server binary naming across all platforms

### Other

- *(deps)* update dependency vite to v7
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).