### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix esbuild vulnerability by upgrading Vite to 6.3.5
 ## [Unreleased]
 
+## [0.1.3](https://github.com/loonghao/rez-lsp-server/compare/v0.1.2...v0.1.3) - 2026-04-12
+
+### Added
+
+- multi-platform .vsix packaging, rez/rez-next detection, fix release-plz
+
 ## [0.1.0] - 2024-12-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rez-lsp-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rez-lsp-server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 description = "A Language Server Protocol implementation for Rez package manager with intelligent code completion, validation, and navigation"


### PR DESCRIPTION



## 🤖 New release

* `rez-lsp-server`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/loonghao/rez-lsp-server/compare/v0.1.1...v0.1.2) - 2025-06-27

### Fixed

- resolve release-plz multiple triggers and VSCode extension publishing issues
- unify server binary naming across all platforms

### Other

- *(deps)* update dependency vite to v7
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).